### PR TITLE
Fix invalid bind in ssh-deploy-prefix-map

### DIFF
--- a/ssh-deploy.el
+++ b/ssh-deploy.el
@@ -1455,7 +1455,7 @@ if it is configured for deployment."
 
 (defvar ssh-deploy-prefix-map
   (let ((map (make-sparse-keymap)))
-    (define-key map "f" 'ssh-deploy-upload-handler-force)
+    (define-key map "f" 'ssh-deploy-upload-handler-forced)
     (define-key map "u" 'ssh-deploy-upload-handler)
     (define-key map "D" 'ssh-deploy-delete-handler)
     (define-key map "d" 'ssh-deploy-download-handler)


### PR DESCRIPTION
The hydra is correct, but the keymap isn't:
https://github.com/cjohansson/emacs-ssh-deploy/blob/95fb076c9b657c5f1bfad3ee5bf1f8691c50d428/ssh-deploy-hydra.el#L62